### PR TITLE
Feature: Handling networks labeled with "bgplb_advertise" in real-time + code corrections

### DIFF
--- a/bgp_utils.go
+++ b/bgp_utils.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 
 	apiGoBGP "github.com/osrg/gobgp/v3/api"
 	loggerGoBGP "github.com/osrg/gobgp/v3/pkg/log"
@@ -201,5 +202,119 @@ func delBgpRoute(prefix string, mask int, ipFamily apiGoBGP.Family_Afi) error {
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+func isPrefixAdvertised(ctx context.Context, prefix string) bool {
+	_, ipnet, err := net.ParseCIDR(prefix)
+	if err != nil {
+		return false
+	}
+
+	var counter int
+	callback := func(*apiGoBGP.Destination) { counter++ }
+	request := &apiGoBGP.ListPathRequest{
+		Family:   &apiGoBGP.Family{Afi: apiGoBGP.Family_AFI_IP, Safi: apiGoBGP.Family_SAFI_UNICAST},
+		Prefixes: []*apiGoBGP.TableLookupPrefix{{Prefix: prefix}},
+	}
+
+	if ipnet.IP.To4() == nil && strings.Contains(ipnet.IP.String(), ":") {
+		request.Family.Afi = apiGoBGP.Family_AFI_IP6
+	}
+
+	bgpServer.ListPath(ctx, request, callback)
+
+	return counter > 0
+}
+
+func advertisePrefix(ctx context.Context, prefix string) error {
+	_, ipnet, err := net.ParseCIDR(prefix)
+	if err != nil {
+		return fmt.Errorf("advertisePrefix: failed to parse the prefix: %w", err)
+	}
+
+	mask, _ := ipnet.Mask.Size()
+	var family apiGoBGP.Family_Afi
+	if ipnet.IP.To4() == nil && strings.Contains(ipnet.IP.String(), ":") {
+		family = apiGoBGP.Family_AFI_IP6
+	} else {
+		family = apiGoBGP.Family_AFI_IP
+	}
+
+	nlri, _ := apb.New(&apiGoBGP.IPAddressPrefix{
+		Prefix:    ipnet.IP.String(),
+		PrefixLen: uint32(mask),
+	})
+	a1, _ := apb.New(&apiGoBGP.OriginAttribute{
+		Origin: 0,
+	})
+	a2, _ := apb.New(&apiGoBGP.NextHopAttribute{
+		NextHop: routerID,
+	})
+	a3, _ := apb.New(&apiGoBGP.AsPathAttribute{
+		Segments: []*apiGoBGP.AsSegment{
+			{
+				Type: 2,
+			},
+		},
+	})
+	attrs := []*apb.Any{a1, a2, a3}
+	if _, err := bgpServer.AddPath(ctx, &apiGoBGP.AddPathRequest{
+		Path: &apiGoBGP.Path{
+			Family: &apiGoBGP.Family{Afi: family, Safi: apiGoBGP.Family_SAFI_UNICAST},
+			Nlri:   nlri,
+			Pattrs: attrs,
+		},
+	}); err != nil {
+		return fmt.Errorf("advertisePrefix: failed to add the prefix: %w", err)
+	}
+
+	return nil
+}
+
+func withdrawPrefix(ctx context.Context, prefix string) error {
+	_, ipnet, err := net.ParseCIDR(prefix)
+	if err != nil {
+		return fmt.Errorf("withdrawPrefix: failed to parse the prefix: %w", err)
+	}
+
+	mask, _ := ipnet.Mask.Size()
+	var family apiGoBGP.Family_Afi
+	if ipnet.IP.To4() == nil && strings.Contains(ipnet.IP.String(), ":") {
+		family = apiGoBGP.Family_AFI_IP6
+	} else {
+		family = apiGoBGP.Family_AFI_IP
+	}
+
+	nlri, _ := apb.New(&apiGoBGP.IPAddressPrefix{
+		Prefix:    ipnet.IP.String(),
+		PrefixLen: uint32(mask),
+	})
+	a1, _ := apb.New(&apiGoBGP.OriginAttribute{
+		Origin: 0,
+	})
+	a2, _ := apb.New(&apiGoBGP.NextHopAttribute{
+		NextHop: routerID,
+	})
+	a3, _ := apb.New(&apiGoBGP.AsPathAttribute{
+		Segments: []*apiGoBGP.AsSegment{
+			{
+				Type: 2,
+			},
+		},
+	})
+	attrs := []*apb.Any{a1, a2, a3}
+	p1 := &apiGoBGP.Path{
+		Family: &apiGoBGP.Family{Afi: family, Safi: apiGoBGP.Family_SAFI_UNICAST},
+		Nlri:   nlri,
+		Pattrs: attrs,
+	}
+	if err := bgpServer.DeletePath(ctx, &apiGoBGP.DeletePathRequest{
+		TableType: apiGoBGP.TableType_GLOBAL,
+		Path:      p1,
+	}); err != nil {
+		return fmt.Errorf("withdrawPrefix: failed to delete the prefix: %w", err)
+	}
+
 	return nil
 }

--- a/bgp_utils.go
+++ b/bgp_utils.go
@@ -14,13 +14,15 @@ import (
 	apb "google.golang.org/protobuf/types/known/anypb"
 )
 
-var bgpServer = serverGoBGP.BgpServer{}
-var routerid = ""
-var localAs = uint32(0)
+var (
+	bgpServer = serverGoBGP.BgpServer{}
+	localAS   = uint32(0)
+	routerID  = ""
+)
 
 func startBgpServer(peerAddress string) error {
-	routerid = os.Getenv("ROUTER_ID")
-	if routerid == "" && net.ParseIP(routerid) == nil {
+	routerID = os.Getenv("ROUTER_ID")
+	if routerID == "" && net.ParseIP(routerID) == nil {
 		return fmt.Errorf("Environment variable ROUTER_ID is required\r\n")
 	}
 
@@ -34,7 +36,7 @@ func startBgpServer(peerAddress string) error {
 	if err != nil {
 		return fmt.Errorf("Environment variable LOCAL_AS value is invalid\r\n")
 	}
-	localAs = uint32(localAsInt)
+	localAS = uint32(localAsInt)
 
 	peerAsInt, err := strconv.Atoi(os.Getenv("PEER_AS"))
 	if err != nil {
@@ -48,8 +50,8 @@ func startBgpServer(peerAddress string) error {
 	go bgpServer.Serve()
 	err = bgpServer.StartBgp(context.Background(), &apiGoBGP.StartBgpRequest{
 		Global: &apiGoBGP.Global{
-			RouterId:   routerid,
-			Asn:        localAs,
+			RouterId:   routerID,
+			Asn:        localAS,
 			ListenPort: routerPort,
 		},
 	})
@@ -81,7 +83,7 @@ func addRoute(NetworkID, EndpointID, ipv4, ipv6 string) {
 		return
 	}
 
-	bridgeName := getBridgeName(NetworkID)
+	bridgeName := getBridgeNameByNetID(NetworkID)
 	bridge, err := netlink.LinkByName(bridgeName)
 	if err != nil {
 		log.Errorf("addRoute error: %v", err)
@@ -105,8 +107,6 @@ func addRoute(NetworkID, EndpointID, ipv4, ipv6 string) {
 
 		addBgpRoute(ip.String(), 128, apiGoBGP.Family_AFI_IP6)
 	}
-
-	return
 }
 
 func addBgpRoute(prefix string, mask int, ipFamily apiGoBGP.Family_Afi) error {
@@ -118,7 +118,7 @@ func addBgpRoute(prefix string, mask int, ipFamily apiGoBGP.Family_Afi) error {
 		Origin: 0,
 	})
 	a2, _ := apb.New(&apiGoBGP.NextHopAttribute{
-		NextHop: routerid,
+		NextHop: routerID,
 	})
 	a3, _ := apb.New(&apiGoBGP.AsPathAttribute{
 		Segments: []*apiGoBGP.AsSegment{
@@ -139,7 +139,7 @@ func addBgpRoute(prefix string, mask int, ipFamily apiGoBGP.Family_Afi) error {
 }
 
 func delRoute(NetworkID, EndpointID string) {
-	bridgeName := getBridgeName(NetworkID)
+	bridgeName := getBridgeNameByNetID(NetworkID)
 	bridge, err := netlink.LinkByName(bridgeName)
 	if err != nil {
 		log.Errorf("delRoute error: %v", err)
@@ -168,8 +168,6 @@ func delRoute(NetworkID, EndpointID string) {
 			log.Errorf("Cannot remove local route to: %v , Error: %v", v6dst.String(), err)
 		}
 	}
-
-	return
 }
 
 func delBgpRoute(prefix string, mask int, ipFamily apiGoBGP.Family_Afi) error {
@@ -181,7 +179,7 @@ func delBgpRoute(prefix string, mask int, ipFamily apiGoBGP.Family_Afi) error {
 		Origin: 0,
 	})
 	a2, _ := apb.New(&apiGoBGP.NextHopAttribute{
-		NextHop: routerid,
+		NextHop: routerID,
 	})
 	a3, _ := apb.New(&apiGoBGP.AsPathAttribute{
 		Segments: []*apiGoBGP.AsSegment{

--- a/bgp_utils.go
+++ b/bgp_utils.go
@@ -23,7 +23,7 @@ var (
 
 func startBgpServer(peerAddress string) error {
 	routerID = os.Getenv("ROUTER_ID")
-	if routerID == "" && net.ParseIP(routerID) == nil {
+	if routerID == "" || net.ParseIP(routerID) == nil {
 		return fmt.Errorf("Environment variable ROUTER_ID is required\r\n")
 	}
 

--- a/bridge_utils.go
+++ b/bridge_utils.go
@@ -11,43 +11,43 @@ import (
 )
 
 const (
-	bridgePrefix = "bgplb"
-	bridgeLen    = 9
+	bridgeNameLen    = 9
+	bridgeNamePrefix = "bgplb"
 )
 
-func getBridgeName(netID string) string {
-	return bridgePrefix + "-" + netID[:bridgeLen]
+func getBridgeNameByNetID(netID string) string {
+	return bridgeNamePrefix + "-" + netID[:bridgeNameLen]
 }
 
-func createBridge(netID string) (string, error) {
-	bridgeName := getBridgeName(netID)
+func createBridgeFromNetID(netID string) error {
+	name := getBridgeNameByNetID(netID)
 
-	exists, err := bridgeInterfaceExists(bridgeName)
+	exists, err := bridgeInterfaceExists(name)
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	if !exists {
 		linkAttrs := netlink.NewLinkAttrs()
-		linkAttrs.Name = bridgeName
+		linkAttrs.Name = name
 
 		if err := netlink.LinkAdd(&netlink.Bridge{
 			LinkAttrs: linkAttrs,
 		}); err != nil {
-			return "", err
+			return err
 		}
 	}
 
-	bridge, err := netlink.LinkByName(bridgeName)
+	bridge, err := netlink.LinkByName(name)
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	if err := patchBridge(bridge); err != nil {
-		return "", err
+		return err
 	}
 
-	return bridgeName, nil
+	return nil
 }
 
 func patchBridge(bridge netlink.Link) error {
@@ -82,7 +82,7 @@ func patchBridge(bridge netlink.Link) error {
 }
 
 func deleteBridge(netID string) error {
-	bridgeName := getBridgeName(netID)
+	bridgeName := getBridgeNameByNetID(netID)
 
 	bridge, err := netlink.LinkByName(bridgeName)
 	if err != nil {

--- a/docker_utils.go
+++ b/docker_utils.go
@@ -25,7 +25,7 @@ var (
 	SIGUSR2Enabled bool
 )
 
-func getGwBridge(ctx context.Context) {
+func advertiseNetworksOnStart(ctx context.Context) {
 	cli, _ := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	err := fmt.Errorf("run once")
 	for err != nil {
@@ -34,6 +34,7 @@ func getGwBridge(ctx context.Context) {
 			time.Sleep(time.Second * 1)
 		}
 	}
+	defer cli.Close()
 
 	networkFilter := filters.NewArgs()
 	networkFilter.Add("label", "bgplb_advertise=true")
@@ -42,20 +43,18 @@ func getGwBridge(ctx context.Context) {
 	}
 	networks, err := cli.NetworkList(ctx, options)
 	if err != nil {
-		log.Errorf("getGwBridge: Error getting networks from Docker: %v\n", err)
+		log.Errorf("advertiseNetworksOnStart: Error getting networks from Docker: %v\n", err)
 		return
 	}
 
 	for _, network := range networks {
-		if !isNetworkAdvertised(network.ID) {
-			log := log.WithField("network.id", network.ID[:11]).WithField("network.name", network.Name)
-			ipamConfigs := network.IPAM.Config
-			for _, ipam := range ipamConfigs {
-				if err := addAdvertisedSubnet(ctx, network.ID, ipam.Subnet); err == nil {
-					log.WithField("subnet", ipam.Subnet).Info("getGwBridge: advertising the subnet")
-				} else {
-					log.WithField("subnet", ipam.Subnet).Errorf("getGwBridge: failed to advertise the subnet: %v", err)
-				}
+		log := log.WithField("network.id", network.ID[:11]).WithField("network.name", network.Name)
+		ipamConfigs := network.IPAM.Config
+		for _, ipam := range ipamConfigs {
+			if err := addAdvertisedSubnet(ctx, network.ID, ipam.Subnet); err == nil {
+				log.WithField("subnet", ipam.Subnet).Info("advertiseNetworksOnStart: advertising the subnet")
+			} else {
+				log.WithField("subnet", ipam.Subnet).Errorf("advertiseNetworksOnStart: failed to advertise the subnet: %v", err)
 			}
 		}
 	}
@@ -69,45 +68,50 @@ func waitContainerHealthy(networkID, endpointID string) bool {
 			log.Errorf("Cannot connect to Docker: %v", err)
 		}
 
-		network, err := cli.NetworkInspect(context.Background(), networkID, types.NetworkInspectOptions{})
+		network, err := cli.NetworkInspect(context.TODO(), networkID, types.NetworkInspectOptions{})
 		if err != nil {
 			log.Errorf("Cannot inspect network: %v", err)
 		}
 
 		if len(network.Containers) == 0 {
 			log.Errorf("No containers found from network %s, skipping BGP route", network.Name)
+			cli.Close()
 			return false
 		}
 
 		for containerID, endpoint := range network.Containers {
-			if endpoint.EndpointID == endpointID {
-				container, _ := cli.ContainerInspect(context.Background(), containerID)
-				log.Infof("waitContainerHealthy, waiting container %s", container.Name)
-				if container.State != nil {
-					if container.State.Health != nil {
-						if container.State.Health.Status == "healthy" {
-							log.Infof("Container %s healthy, adding BGP route(s)", container.Name)
-							return true
-						}
-						if container.State.Health.Status == "unhealthy" {
-							log.Errorf("Container %s is unhealthy, skipping BGP route", container.Name)
-							return false
-						}
-					} else {
-						if container.State.Running == true {
-							log.Infof("Container %s running, adding BGP route(s)", container.Name)
-							return true
-						}
-						if container.State.Status != "created" {
-							log.Errorf("Container %s failed to start, skipping BGP route", container.Name)
-							return false
-						}
+			if endpoint.EndpointID != endpointID {
+				continue
+			}
+			container, _ := cli.ContainerInspect(context.TODO(), containerID)
+			log.Infof("waitContainerHealthy, waiting container %s", container.Name)
+			if container.State != nil {
+				if container.State.Health != nil {
+					if container.State.Health.Status == "healthy" {
+						log.Infof("Container %s healthy, adding BGP route(s)", container.Name)
+						cli.Close()
+						return true
+					}
+					if container.State.Health.Status == "unhealthy" {
+						log.Errorf("Container %s is unhealthy, skipping BGP route", container.Name)
+						cli.Close()
+						return false
+					}
+				} else {
+					if container.State.Running == true {
+						log.Infof("Container %s running, adding BGP route(s)", container.Name)
+						cli.Close()
+						return true
+					}
+					if container.State.Status != "created" {
+						log.Errorf("Container %s failed to start, skipping BGP route", container.Name)
+						cli.Close()
+						return false
 					}
 				}
-			} else {
-				return false
 			}
 		}
+		cli.Close()
 		time.Sleep(1 * time.Second)
 	}
 }
@@ -150,7 +154,9 @@ func watchDockerEvents(ctx context.Context) {
 	backoffConfig := backoff.NewExponentialBackOff(
 		backoff.WithInitialInterval(1*time.Second),
 		backoff.WithMultiplier(1.5),
+		backoff.WithRandomizationFactor(0),
 		backoff.WithMaxInterval(5*time.Second),
+		backoff.WithMaxElapsedTime(0),
 	)
 
 	ticker := backoff.NewTicker(backoffConfig)
@@ -205,6 +211,7 @@ func watchDockerEvents(ctx context.Context) {
 				}
 			}
 			cli.Close()
+			backoffConfig.Reset()
 
 		case <-ctx.Done():
 			log.Warnf("watchDockerEvents: exiting due to: %v", ctx.Err())
@@ -220,15 +227,13 @@ func handleDockerNetworkCreate(ctx context.Context, cli *client.Client, event *e
 		log.Errorf("handleDockerNetworkCreate: cannot inspect the network: %v", err)
 		return
 	}
-	if !isNetworkAdvertised(network.ID) {
-		log = log.WithField("network.name", network.Name)
-		if l, ok := network.Labels["bgplb_advertise"]; ok && l == "true" {
-			for _, ipam := range network.IPAM.Config {
-				if err := addAdvertisedSubnet(ctx, network.ID, ipam.Subnet); err == nil {
-					log.WithField("subnet", ipam.Subnet).Info("handleDockerNetworkCreate: advertising the subnet")
-				} else {
-					log.WithField("subnet", ipam.Subnet).Errorf("handleDockerNetworkCreate: failed to advertise the subnet: %v", err)
-				}
+	log = log.WithField("network.name", network.Name)
+	if l, ok := network.Labels["bgplb_advertise"]; ok && l == "true" {
+		for _, ipam := range network.IPAM.Config {
+			if err := addAdvertisedSubnet(ctx, network.ID, ipam.Subnet); err == nil {
+				log.WithField("subnet", ipam.Subnet).Info("handleDockerNetworkCreate: advertising the subnet")
+			} else {
+				log.WithField("subnet", ipam.Subnet).Errorf("handleDockerNetworkCreate: failed to advertise the subnet: %v", err)
 			}
 		}
 	}
@@ -236,12 +241,10 @@ func handleDockerNetworkCreate(ctx context.Context, cli *client.Client, event *e
 
 func handleDockerNetworkDestroy(ctx context.Context, event *events.Message) {
 	log := log.WithField("network.id", event.Actor.ID[:11])
-	if isNetworkAdvertised(event.Actor.ID) {
-		if err := delAdvertisedNetwork(ctx, event.Actor.ID); err == nil {
-			log.Info("handleDockerNetworkDestroy: removed the advertised network")
-		} else {
-			log.Errorf("handleDockerNetworkDestroy: failed to remove the advertised network: %v", err)
-		}
+	if err := delAdvertisedNetwork(ctx, event.Actor.ID); err == nil {
+		log.Info("handleDockerNetworkDestroy: removed the advertised network")
+	} else {
+		log.Errorf("handleDockerNetworkDestroy: failed to remove the advertised network: %v", err)
 	}
 }
 
@@ -249,7 +252,7 @@ func handleDockerContainerKill(ctx context.Context, cli *client.Client, event *e
 	log := log.WithField("container.id", event.Actor.ID[:11])
 	if event.Actor.Attributes["signal"] == SIGUSR2Number {
 		log.Info("SIGUSR2 signal received. Gracefully drain the load")
-		delContainerRoutes(event.ID, cli)
+		delContainerRoutes(event.Actor.ID, cli)
 
 		if SIGUSR2Action == "stop" {
 			log.Info("Stopping the container due to the 'SIGUSR2_ACTION=stop'")

--- a/docker_utils.go
+++ b/docker_utils.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
@@ -27,7 +29,7 @@ func getGwBridge(ctx context.Context) {
 	cli, _ := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	err := fmt.Errorf("run once")
 	for err != nil {
-		_, err = cli.ServerVersion(context.Background())
+		_, err = cli.ServerVersion(ctx)
 		if err != nil {
 			time.Sleep(time.Second * 1)
 		}
@@ -138,18 +140,30 @@ func delContainerRoutes(containerID string, cli *client.Client) {
 }
 
 func watchDockerEvents(ctx context.Context) {
-	timer := time.NewTimer(1 * time.Second)
-	defer timer.Stop()
+	if os.Getenv("SIGUSR2_HANDLER") == "true" {
+		log.Info("Enabling SIGUSR2 signal handler")
+
+		SIGUSR2Enabled = true
+		SIGUSR2Action = (os.Getenv("SIGUSR2_ACTION"))
+	}
+
+	backoffConfig := backoff.NewExponentialBackOff(
+		backoff.WithInitialInterval(1*time.Second),
+		backoff.WithMultiplier(1.5),
+		backoff.WithMaxInterval(5*time.Second),
+	)
+
+	ticker := backoff.NewTicker(backoffConfig)
+	defer ticker.Stop()
 
 	for {
 		select {
-		case <-timer.C:
+		case <-ticker.C:
 			cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 			if err != nil {
 				log.Errorf("watchDockerEvents: cannot connect to Docker: %v", err)
 				break
 			}
-			defer cli.Close()
 
 			eventFilters := filters.NewArgs(
 				filters.Arg("type", "network"),
@@ -157,11 +171,7 @@ func watchDockerEvents(ctx context.Context) {
 				filters.Arg("action", "destroy"),
 			)
 
-			if os.Getenv("SIGUSR2_HANDLER") == "true" {
-				log.Info("Enabling SIGUSR2 signal handler")
-
-				SIGUSR2Enabled = true
-				SIGUSR2Action = (os.Getenv("SIGUSR2_ACTION"))
+			if SIGUSR2Enabled {
 				eventFilters.Add("type", "container")
 				eventFilters.Add("action", "kill")
 			}
@@ -194,6 +204,7 @@ func watchDockerEvents(ctx context.Context) {
 					break eventLoop
 				}
 			}
+			cli.Close()
 
 		case <-ctx.Done():
 			log.Warnf("watchDockerEvents: exiting due to: %v", ctx.Err())

--- a/docker_utils.go
+++ b/docker_utils.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	driverName = "ollijanatuinen/docker-bgp-lb:v1.7"
-	SIGUSR2    = "12"
+	dockerDriverName = "ollijanatuinen/docker-bgp-lb:v1.7"
+	SIGUSR2          = "12"
 )
 
 func getGwBridge() {
@@ -161,7 +161,7 @@ func stopContainer(containerID string, cli *client.Client) {
 
 func delContainerRoutes(containerID string, cli *client.Client) {
 	networkFilter := filters.NewArgs()
-	networkFilter.Add("driver", driverName)
+	networkFilter.Add("driver", dockerDriverName)
 	options := types.NetworkListOptions{
 		Filters: networkFilter,
 	}

--- a/docker_utils.go
+++ b/docker_utils.go
@@ -3,23 +3,27 @@ package main
 import (
 	"context"
 	"fmt"
-	"net"
-	"strings"
+	"os"
 	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
-	apiGoBGP "github.com/osrg/gobgp/v3/api"
 )
 
 const (
 	dockerDriverName = "ollijanatuinen/docker-bgp-lb:v1.7"
-	SIGUSR2          = "12"
+	SIGUSR2Number    = "12"
 )
 
-func getGwBridge() {
+var (
+	SIGUSR2Action  string
+	SIGUSR2Enabled bool
+)
+
+func getGwBridge(ctx context.Context) {
 	cli, _ := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	err := fmt.Errorf("run once")
 	for err != nil {
@@ -34,28 +38,22 @@ func getGwBridge() {
 	options := types.NetworkListOptions{
 		Filters: networkFilter,
 	}
-	networks, err := cli.NetworkList(context.Background(), options)
+	networks, err := cli.NetworkList(ctx, options)
 	if err != nil {
 		log.Errorf("getGwBridge: Error getting networks from Docker: %v\n", err)
 		return
 	}
 
 	for _, network := range networks {
-		fmt.Printf("Network name: %v\r\n", network.Name)
-		ipamConfigs := network.IPAM.Config
-		for _, ipam := range ipamConfigs {
-			_, ipnet, err := net.ParseCIDR(ipam.Subnet)
-			if err != nil {
-				log.Errorf("getGwBridge: Failed to parse IPAM subnet : %v\n", err)
-				return
-			}
-			mask, _ := ipnet.Mask.Size()
-			if ipnet.IP.To4() == nil && strings.Contains(ipnet.IP.String(), ":") {
-				log.Infof("Adding BGP route to local BGP LB gateway IPv6 subnet: %v/%v", ipnet.IP.String(), mask)
-				addBgpRoute(ipnet.IP.String(), mask, apiGoBGP.Family_AFI_IP6)
-			} else {
-				log.Infof("Adding BGP route to local BGP LB gateway IPv4 subnet: %v/%v", ipnet.IP.String(), mask)
-				addBgpRoute(ipnet.IP.String(), mask, apiGoBGP.Family_AFI_IP)
+		if !isNetworkAdvertised(network.ID) {
+			log := log.WithField("network.id", network.ID[:11]).WithField("network.name", network.Name)
+			ipamConfigs := network.IPAM.Config
+			for _, ipam := range ipamConfigs {
+				if err := addAdvertisedSubnet(ctx, network.ID, ipam.Subnet); err == nil {
+					log.WithField("subnet", ipam.Subnet).Info("getGwBridge: advertising the subnet")
+				} else {
+					log.WithField("subnet", ipam.Subnet).Errorf("getGwBridge: failed to advertise the subnet: %v", err)
+				}
 			}
 		}
 	}
@@ -112,53 +110,6 @@ func waitContainerHealthy(networkID, endpointID string) bool {
 	}
 }
 
-func watchDockerStopEvents(action string) {
-	cli, _ := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
-	err := fmt.Errorf("run once")
-	for err != nil {
-		_, err = cli.ServerVersion(context.Background())
-		if err != nil {
-			time.Sleep(time.Second * 1)
-		}
-	}
-
-	eventFilter := filters.NewArgs()
-	eventFilter.Add("event", "kill")
-	options := types.EventsOptions{
-		Filters: eventFilter,
-	}
-	messages, errs := cli.Events(context.Background(), options)
-
-	for {
-		select {
-		case event := <-messages:
-			if event.Actor.Attributes["signal"] == SIGUSR2 {
-				log.Infof("SIGUSR2 signal received from container ID %s, deleting BGP route(s)", event.ID)
-				delContainerRoutes(event.ID, cli)
-				if action == "stop" {
-					go stopContainer(event.ID, cli)
-				}
-			}
-		case err := <-errs:
-			if err != nil {
-				log.Errorf("watchDockerEvents: Error: %v\n", err)
-				time.Sleep(1 * time.Second)
-			}
-		}
-	}
-}
-
-func stopContainer(containerID string, cli *client.Client) {
-	time.Sleep(5 * time.Second)
-
-	timeout := -1
-	options := container.StopOptions{
-		Signal:  "SIGTERM",
-		Timeout: &timeout,
-	}
-	cli.ContainerStop(context.Background(), containerID, options)
-}
-
 func delContainerRoutes(containerID string, cli *client.Client) {
 	networkFilter := filters.NewArgs()
 	networkFilter.Add("driver", dockerDriverName)
@@ -182,6 +133,119 @@ func delContainerRoutes(containerID string, cli *client.Client) {
 			if network.ID == containerNetwork.NetworkID {
 				go delRoute(containerNetwork.NetworkID, containerNetwork.EndpointID)
 			}
+		}
+	}
+}
+
+func watchDockerEvents(ctx context.Context) {
+	timer := time.NewTimer(1 * time.Second)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-timer.C:
+			cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+			if err != nil {
+				log.Errorf("watchDockerEvents: cannot connect to Docker: %v", err)
+				break
+			}
+			defer cli.Close()
+
+			eventFilters := filters.NewArgs(
+				filters.Arg("type", "network"),
+				filters.Arg("action", "create"),
+				filters.Arg("action", "destroy"),
+			)
+
+			if os.Getenv("SIGUSR2_HANDLER") == "true" {
+				log.Info("Enabling SIGUSR2 signal handler")
+
+				SIGUSR2Enabled = true
+				SIGUSR2Action = (os.Getenv("SIGUSR2_ACTION"))
+				eventFilters.Add("type", "container")
+				eventFilters.Add("action", "kill")
+			}
+
+			eventOptions := types.EventsOptions{Filters: eventFilters}
+			messages, errors := cli.Events(ctx, eventOptions)
+
+		eventLoop:
+			for {
+				select {
+				case event := <-messages:
+					if event.Type == events.NetworkEventType {
+						switch event.Action {
+						case events.ActionCreate:
+							handleDockerNetworkCreate(ctx, cli, &event)
+						case events.ActionDestroy:
+							handleDockerNetworkDestroy(ctx, &event)
+						}
+					}
+					if event.Type == events.ContainerEventType {
+						if event.Action == events.ActionKill {
+							if SIGUSR2Enabled {
+								handleDockerContainerKill(ctx, cli, &event)
+							}
+						}
+					}
+
+				case err := <-errors:
+					log.Warnf("watchDockerEvents: restarting due to: %v", err)
+					break eventLoop
+				}
+			}
+
+		case <-ctx.Done():
+			log.Warnf("watchDockerEvents: exiting due to: %v", ctx.Err())
+			return
+		}
+	}
+}
+
+func handleDockerNetworkCreate(ctx context.Context, cli *client.Client, event *events.Message) {
+	log := log.WithField("network.id", event.Actor.ID[:11])
+	network, err := cli.NetworkInspect(ctx, event.Actor.ID, types.NetworkInspectOptions{})
+	if err != nil {
+		log.Errorf("handleDockerNetworkCreate: cannot inspect the network: %v", err)
+		return
+	}
+	if !isNetworkAdvertised(network.ID) {
+		log = log.WithField("network.name", network.Name)
+		if l, ok := network.Labels["bgplb_advertise"]; ok && l == "true" {
+			for _, ipam := range network.IPAM.Config {
+				if err := addAdvertisedSubnet(ctx, network.ID, ipam.Subnet); err == nil {
+					log.WithField("subnet", ipam.Subnet).Info("handleDockerNetworkCreate: advertising the subnet")
+				} else {
+					log.WithField("subnet", ipam.Subnet).Errorf("handleDockerNetworkCreate: failed to advertise the subnet: %v", err)
+				}
+			}
+		}
+	}
+}
+
+func handleDockerNetworkDestroy(ctx context.Context, event *events.Message) {
+	log := log.WithField("network.id", event.Actor.ID[:11])
+	if isNetworkAdvertised(event.Actor.ID) {
+		if err := delAdvertisedNetwork(ctx, event.Actor.ID); err == nil {
+			log.Info("handleDockerNetworkDestroy: removed the advertised network")
+		} else {
+			log.Errorf("handleDockerNetworkDestroy: failed to remove the advertised network: %v", err)
+		}
+	}
+}
+
+func handleDockerContainerKill(ctx context.Context, cli *client.Client, event *events.Message) {
+	log := log.WithField("container.id", event.Actor.ID[:11])
+	if event.Actor.Attributes["signal"] == SIGUSR2Number {
+		log.Info("SIGUSR2 signal received. Gracefully drain the load")
+		delContainerRoutes(event.ID, cli)
+
+		if SIGUSR2Action == "stop" {
+			log.Info("Stopping the container due to the 'SIGUSR2_ACTION=stop'")
+			go func() {
+				time.Sleep(5 * time.Second)
+				cli.ContainerStop(ctx, event.Actor.ID, container.StopOptions{Signal: "SIGTERM"})
+			}()
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 )
 
 require (
+	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/google/uuid v1.6.0
 	github.com/osrg/gobgp/v3 v3.25.0
 	google.golang.org/protobuf v1.33.0

--- a/main.go
+++ b/main.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/davecgh/go-spew/spew"
@@ -14,6 +17,7 @@ import (
 )
 
 var driverScope = "local"
+var lbServer *bgpLB
 var log = &logrus.Logger{}
 var scs = spew.ConfigState{Indent: "  "}
 var stateFile = "/bgplb.json"
@@ -28,8 +32,10 @@ type bgpNetwork struct {
 }
 
 type bgpLB struct {
-	scope    string
 	Networks map[string]*bgpNetwork
+
+	advertisedNetworks map[string][]string
+	scope              string
 	sync.Mutex
 }
 
@@ -113,7 +119,7 @@ func (d *bgpLB) CreateNetwork(r *api.CreateNetworkRequest) error {
 	}
 
 	d.Networks[r.NetworkID] = bgpNetwork
-	err = d.save()
+	err = d.saveState()
 	if err != nil {
 		return err
 	}
@@ -136,7 +142,7 @@ func (d *bgpLB) DeleteNetwork(r *api.DeleteNetworkRequest) error {
 	}
 
 	delete(d.Networks, r.NetworkID)
-	err = d.save()
+	err = d.saveState()
 	if err != nil {
 		return err
 	}
@@ -291,15 +297,15 @@ func (d *bgpLB) RevokeExternalConnectivity(r *api.RevokeExternalConnectivityRequ
 	return nil
 }
 
-func (d *bgpLB) save() error {
-	data, err := json.Marshal(d)
+func (lb *bgpLB) saveState() error {
+	data, err := json.Marshal(lb)
 	if err != nil {
 		return err
 	}
 	return os.WriteFile(stateFile, data, 0644)
 }
 
-func load() (*bgpLB, error) {
+func loadState() (*bgpLB, error) {
 	data, err := os.ReadFile(stateFile)
 	if err != nil {
 		return nil, err
@@ -312,6 +318,54 @@ func load() (*bgpLB, error) {
 	return &b, nil
 }
 
+func isNetworkAdvertised(netID string) bool {
+	lbServer.Lock()
+	defer lbServer.Unlock()
+
+	_, ok := lbServer.advertisedNetworks[netID]
+
+	return ok
+}
+
+func addAdvertisedSubnet(ctx context.Context, netID, subnet string) error {
+	lbServer.Lock()
+	defer lbServer.Unlock()
+
+	if !isPrefixAdvertised(ctx, subnet) {
+		if err := advertisePrefix(ctx, subnet); err != nil {
+			return fmt.Errorf("addAdvertisedSubnet: failed to advertise the subnet: %w", err)
+		}
+	}
+
+	lbServer.advertisedNetworks[netID] = append(lbServer.advertisedNetworks[netID], subnet)
+	return nil
+}
+
+func delAdvertisedNetwork(ctx context.Context, netID string) error {
+	lbServer.Lock()
+	defer lbServer.Unlock()
+
+	subnets, ok := lbServer.advertisedNetworks[netID]
+	if !ok {
+		return fmt.Errorf("delAdvertisedNetwork: network is not advertised")
+	}
+
+	var errs []string
+	for _, subnet := range subnets {
+		if isPrefixAdvertised(ctx, subnet) {
+			if err := withdrawPrefix(ctx, subnet); err != nil {
+				errs = append(errs, fmt.Sprintf("withdrawPrefix(%s) => %s", subnet, err))
+			}
+		}
+	}
+
+	if errs != nil {
+		return fmt.Errorf("delAdvertisedNetwork: %s", strings.Join(errs, ", "))
+	}
+
+	return nil
+}
+
 func main() {
 	log = &logrus.Logger{
 		Out:   os.Stdout,
@@ -322,6 +376,9 @@ func main() {
 		},
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	peerAddress := os.Getenv("PEER_ADDRESS")
 	if net.ParseIP(peerAddress) != nil {
 		err := startBgpServer(peerAddress)
@@ -329,12 +386,7 @@ func main() {
 			log.Errorf("Starting BGP server failed: %v", err)
 			return
 		}
-		go getGwBridge()
-	}
-
-	if os.Getenv("SIGUSR2_HANDLER") == "true" {
-		log.Infof("Starting SIGUSR2 signal handler")
-		go watchDockerStopEvents(os.Getenv("SIGUSR2_ACTION"))
+		go getGwBridge(ctx)
 	}
 
 	if os.Getenv("GLOBAL_SCOPE") == "true" {
@@ -343,36 +395,38 @@ func main() {
 
 	log.Infof("Starting Docker BGP LB Plugin")
 
+	lbServer = &bgpLB{
+		advertisedNetworks: make(map[string][]string),
+		scope:              driverScope,
+	}
+	go watchDockerEvents(ctx)
+
 	// Load saves networks configuration but only when we are not running in swarm mode.
 	// This is because swarm will automatically create/remove networks when needed.
-	var d *bgpLB
-	var err error
-	if os.Getenv("GLOBAL_SCOPE") == "true" {
-		log.Info("Running in Swarm mode, starting with an empty configuration:", err)
-		d = &bgpLB{
-			scope:    driverScope,
-			Networks: make(map[string]*bgpNetwork),
-		}
+	lbServer.Lock()
+	if driverScope == "global" {
+		log.Info("Running in Swarm mode, starting with an empty configuration.")
+		lbServer.Networks = make(map[string]*bgpNetwork)
 	} else {
-		d, err = load()
+		d, err := loadState()
 		if err != nil {
-			log.Info("Failed to load data, starting with an empty configuration:", err)
-			d = &bgpLB{
-				scope:    driverScope,
-				Networks: make(map[string]*bgpNetwork),
-			}
+			log.Info("Failed to load data, starting with an empty configuration.")
+			lbServer.Networks = make(map[string]*bgpNetwork)
+		} else {
+			lbServer.Networks = d.Networks
 		}
 	}
 
-	for id, network := range d.Networks {
+	for id, network := range lbServer.Networks {
 		if err := createBridgeFromNetID(id); err != nil {
 			log.Printf("Failed to create bridge for network %s: %v", id, err)
 		}
 		network.endpoints = make(map[string]*bgpLBEndpoint)
 	}
+	lbServer.Unlock()
 
-	h := api.NewHandler(d)
-	if err = h.ServeUnix("bgplb", 0); err != nil {
+	h := api.NewHandler(lbServer)
+	if err := h.ServeUnix("bgplb", 0); err != nil {
 		log.Errorf("ServeUnix failed: %v", err)
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"strings"
+	"slices"
 	"sync"
 
 	"github.com/davecgh/go-spew/spew"
@@ -31,10 +31,15 @@ type bgpNetwork struct {
 	endpoints map[string]*bgpLBEndpoint
 }
 
+type advertisedNetwork struct {
+	subnets []string
+	sync.Mutex
+}
+
 type bgpLB struct {
 	Networks map[string]*bgpNetwork
 
-	advertisedNetworks map[string][]string
+	advertisedNetworks map[string]*advertisedNetwork
 	scope              string
 	sync.Mutex
 }
@@ -318,52 +323,67 @@ func loadState() (*bgpLB, error) {
 	return &b, nil
 }
 
-func isNetworkAdvertised(netID string) bool {
-	lbServer.Lock()
-	defer lbServer.Unlock()
-
-	_, ok := lbServer.advertisedNetworks[netID]
-
-	return ok
-}
-
 func addAdvertisedSubnet(ctx context.Context, netID, subnet string) error {
+	net := &advertisedNetwork{}
+
 	lbServer.Lock()
-	defer lbServer.Unlock()
+	if n, ok := lbServer.advertisedNetworks[netID]; !ok {
+		lbServer.advertisedNetworks[netID] = net
+	} else {
+		net = n
+	}
+	lbServer.Unlock()
+
+	net.Lock()
+	if slices.Contains(net.subnets, subnet) {
+		net.Unlock()
+		return fmt.Errorf("addAdvertisedSubnet: the subnet '%s' is already advertised", subnet)
+	}
+	// reserve the subnet before the external call
+	net.subnets = append(net.subnets, subnet)
+	net.Unlock()
 
 	if !isPrefixAdvertised(ctx, subnet) {
 		if err := advertisePrefix(ctx, subnet); err != nil {
+			net.Lock()
+			// remove the reserved subnet if advertising failed
+			idx := slices.Index(net.subnets, subnet)
+			if idx >= 0 {
+				net.subnets = slices.Delete(net.subnets, idx, idx+1)
+			}
+			net.Unlock()
 			return fmt.Errorf("addAdvertisedSubnet: failed to advertise the subnet: %w", err)
 		}
 	}
 
-	lbServer.advertisedNetworks[netID] = append(lbServer.advertisedNetworks[netID], subnet)
 	return nil
 }
 
 func delAdvertisedNetwork(ctx context.Context, netID string) error {
 	lbServer.Lock()
-	defer lbServer.Unlock()
 
-	subnets, ok := lbServer.advertisedNetworks[netID]
+	net, ok := lbServer.advertisedNetworks[netID]
 	if !ok {
-		return fmt.Errorf("delAdvertisedNetwork: network is not advertised")
+		lbServer.Unlock()
+		return fmt.Errorf("delAdvertisedNetwork: network '%s' is not advertised", netID[:11])
 	}
+	lbServer.Unlock()
 
-	var errs []string
+	net.Lock()
+	subnets := append([]string(nil), net.subnets...)
+	net.Unlock()
+
 	for _, subnet := range subnets {
 		if isPrefixAdvertised(ctx, subnet) {
 			if err := withdrawPrefix(ctx, subnet); err != nil {
-				errs = append(errs, fmt.Sprintf("withdrawPrefix(%s) => %s", subnet, err))
+				return fmt.Errorf("delAdvertisedNetwork: failed to withdraw the subnet %w", err)
 			}
 		}
 	}
 
-	if errs != nil {
-		return fmt.Errorf("delAdvertisedNetwork: %s", strings.Join(errs, ", "))
-	}
-
+	lbServer.Lock()
 	delete(lbServer.advertisedNetworks, netID)
+	lbServer.Unlock()
 	return nil
 }
 
@@ -386,13 +406,14 @@ func main() {
 		return
 	}
 
-	if net.ParseIP(peerAddress) != nil {
-		err := startBgpServer(peerAddress)
-		if err != nil {
-			log.Errorf("Starting BGP server failed: %v", err)
-			return
-		}
-		go getGwBridge(ctx)
+	if net.ParseIP(peerAddress) == nil {
+		log.Errorf("Value of PEER_ADDRESS is not a valid IP address. Got: %s", peerAddress)
+		return
+	}
+
+	if err := startBgpServer(peerAddress); err != nil {
+		log.Errorf("Starting BGP server failed: %v", err)
+		return
 	}
 
 	if os.Getenv("GLOBAL_SCOPE") == "true" {
@@ -402,11 +423,11 @@ func main() {
 	log.Infof("Starting Docker BGP LB Plugin")
 
 	lbServer = &bgpLB{
-		advertisedNetworks: make(map[string][]string),
+		advertisedNetworks: make(map[string]*advertisedNetwork),
 		scope:              driverScope,
 	}
+	go advertiseNetworksOnStart(ctx)
 	go watchDockerEvents(ctx)
-
 	// Load saves networks configuration but only when we are not running in swarm mode.
 	// This is because swarm will automatically create/remove networks when needed.
 	lbServer.Lock()

--- a/main.go
+++ b/main.go
@@ -13,20 +13,18 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var scs = spew.ConfigState{Indent: "  "}
-var log = logrus.Logger{}
-var stateFile = "/bgplb.json"
 var driverScope = "local"
+var log = &logrus.Logger{}
+var scs = spew.ConfigState{Indent: "  "}
+var stateFile = "/bgplb.json"
 
 type bgpLBEndpoint struct {
-	macAddress  net.HardwareAddr
 	vethInside  string
 	vethOutside string
 }
 
 type bgpNetwork struct {
-	bridgeName string
-	endpoints  map[string]*bgpLBEndpoint
+	endpoints map[string]*bgpLBEndpoint
 }
 
 type bgpLB struct {
@@ -105,14 +103,13 @@ func (d *bgpLB) CreateNetwork(r *api.CreateNetworkRequest) error {
 		return types.ForbiddenErrorf("network %s exists", r.NetworkID)
 	}
 
-	bridgeName, err := createBridge(r.NetworkID)
+	err := createBridgeFromNetID(r.NetworkID)
 	if err != nil {
 		return err
 	}
 
 	bgpNetwork := &bgpNetwork{
-		bridgeName: bridgeName,
-		endpoints:  make(map[string]*bgpLBEndpoint),
+		endpoints: make(map[string]*bgpLBEndpoint),
 	}
 
 	d.Networks[r.NetworkID] = bgpNetwork
@@ -164,18 +161,9 @@ func (d *bgpLB) CreateEndpoint(r *api.CreateEndpointRequest) (*api.CreateEndpoin
 		return nil, types.ForbiddenErrorf("%s network does not exist", r.NetworkID)
 	}
 
-	intfInfo := new(api.EndpointInterface)
-	parsedMac, _ := net.ParseMAC(intfInfo.MacAddress)
+	d.Networks[r.NetworkID].endpoints[r.EndpointID] = &bgpLBEndpoint{}
 
-	endpoint := &bgpLBEndpoint{
-		macAddress: parsedMac,
-	}
-
-	d.Networks[r.NetworkID].endpoints[r.EndpointID] = endpoint
-
-	resp := &api.CreateEndpointResponse{
-		Interface: intfInfo,
-	}
+	resp := &api.CreateEndpointResponse{}
 
 	// Start Goroutine which will add local and BGP routes after container is up and running
 	go addRoute(r.NetworkID, r.EndpointID, r.Interface.Address, r.Interface.AddressIPv6)
@@ -218,7 +206,7 @@ func (d *bgpLB) EndpointInfo(r *api.InfoRequest) (*api.InfoResponse, error) {
 	value := make(map[string]string)
 
 	value["ip_address"] = ""
-	value["mac_address"] = endpointInfo.macAddress.String()
+	value["mac_address"] = ""
 	value["veth_outside"] = endpointInfo.vethOutside
 
 	resp := &api.InfoResponse{
@@ -241,13 +229,12 @@ func (d *bgpLB) Join(r *api.JoinRequest) (*api.JoinResponse, error) {
 		return nil, types.ForbiddenErrorf("%s endpoint does not exist", r.NetworkID)
 	}
 
-	endpointInfo := d.Networks[r.NetworkID].endpoints[r.EndpointID]
-	vethInside, vethOutside, err := createVethPair(endpointInfo.macAddress)
+	vethInside, vethOutside, err := createVethPair()
 	if err != nil {
 		return nil, err
 	}
 
-	if err := attachInterfaceToBridge(d.Networks[r.NetworkID].bridgeName, vethOutside); err != nil {
+	if err := attachInterfaceToBridge(getBridgeNameByNetID(r.NetworkID), vethOutside); err != nil {
 		return nil, err
 	}
 
@@ -326,9 +313,14 @@ func load() (*bgpLB, error) {
 }
 
 func main() {
-	log = *logrus.New()
-	log.SetLevel(logrus.DebugLevel)
-	log.Out = os.Stdout
+	log = &logrus.Logger{
+		Out:   os.Stdout,
+		Level: logrus.DebugLevel,
+		Formatter: &logrus.TextFormatter{
+			FullTimestamp:          true,
+			DisableLevelTruncation: true,
+		},
+	}
 
 	peerAddress := os.Getenv("PEER_ADDRESS")
 	if net.ParseIP(peerAddress) != nil {
@@ -356,7 +348,7 @@ func main() {
 	var d *bgpLB
 	var err error
 	if os.Getenv("GLOBAL_SCOPE") == "true" {
-		log.Println("Running in Swarm mode, starting with an empty configuration:", err)
+		log.Info("Running in Swarm mode, starting with an empty configuration:", err)
 		d = &bgpLB{
 			scope:    driverScope,
 			Networks: make(map[string]*bgpNetwork),
@@ -364,7 +356,7 @@ func main() {
 	} else {
 		d, err = load()
 		if err != nil {
-			log.Println("Failed to load data, starting with an empty configuration:", err)
+			log.Info("Failed to load data, starting with an empty configuration:", err)
 			d = &bgpLB{
 				scope:    driverScope,
 				Networks: make(map[string]*bgpNetwork),
@@ -373,10 +365,9 @@ func main() {
 	}
 
 	for id, network := range d.Networks {
-		if _, err := createBridge(id); err != nil {
+		if err := createBridgeFromNetID(id); err != nil {
 			log.Printf("Failed to create bridge for network %s: %v", id, err)
 		}
-		network.bridgeName = getBridgeName(id)
 		network.endpoints = make(map[string]*bgpLBEndpoint)
 	}
 

--- a/main.go
+++ b/main.go
@@ -363,6 +363,7 @@ func delAdvertisedNetwork(ctx context.Context, netID string) error {
 		return fmt.Errorf("delAdvertisedNetwork: %s", strings.Join(errs, ", "))
 	}
 
+	delete(lbServer.advertisedNetworks, netID)
 	return nil
 }
 
@@ -380,6 +381,11 @@ func main() {
 	defer cancel()
 
 	peerAddress := os.Getenv("PEER_ADDRESS")
+	if peerAddress == "" {
+		log.Error("Environment variable PEER_ADDRESS is required")
+		return
+	}
+
 	if net.ParseIP(peerAddress) != nil {
 		err := startBgpServer(peerAddress)
 		if err != nil {

--- a/veth_utils.go
+++ b/veth_utils.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"net"
 	"strings"
 
 	"github.com/google/uuid"
@@ -9,23 +8,22 @@ import (
 )
 
 const (
-	vethPrefix = "veth"
-	vethLen    = 8
+	vethNameLen    = 8
+	vethNamePrefix = "veth"
 )
 
-func randomVethName() string {
+func getVethRandomName() string {
 	randomUuid, _ := uuid.NewRandom()
 
-	return vethPrefix + strings.Replace(randomUuid.String(), "-", "", -1)[:vethLen]
+	return vethNamePrefix + strings.Replace(randomUuid.String(), "-", "", -1)[:vethNameLen]
 }
 
-func createVethPair(macAddress net.HardwareAddr) (string, string, error) {
-	vethName1 := randomVethName()
-	vethName2 := randomVethName()
+func createVethPair() (string, string, error) {
+	vethName1 := getVethRandomName()
+	vethName2 := getVethRandomName()
 
 	linkAttrs := netlink.NewLinkAttrs()
 	linkAttrs.Name = vethName1
-	linkAttrs.HardwareAddr = macAddress
 
 	if err := netlink.LinkAdd(&netlink.Veth{
 		LinkAttrs: linkAttrs,


### PR DESCRIPTION
I collected some decorations and tweaks while exploring the codebase. For me, these make reading cleaner.

1. Renamed variables:

   - `routerid` -> `routerID`
   - `localAs` -> `localAS`
   - `bridgePrefix` -> `bridgeNamePrefix`
   - `bridgeLen` -> `bridgeNameLen`
   - `vethPrefix` -> `vethNamePrefix`
   - `vethLen` -> `vethNameLen`
   - `driverName` -> `dockerDriverName`

2. Renamed functions:

   - `getBridgeName()` -> `getBridgeNameByNetID()`
   - `createBridge()` -> `createBridgeFromNetID()`
   - `randomVethName()` -> `getVethRandomName()`

3. The redundant field `bgpNetwork.bridgeName` was removed, and all occurrences were replaced with calls to `getBridgeNameByNetID()`
4. Due to the removal of the `bgpNetwork.bridgeName`, `createBridgeFromNetID()` now returns only an `error`
5. The argument from `createVethPair()` was removed

   - `netlink.LinkAdd()` does not require a MAC address
   - The only call to `createVethpair()` supplied the `endpointInfo.macAddress`, which was always empty due to this code:

     ```go intfInfo := new(EndpointInterface) // {Address: "", AddressIPv6: "", MacAddress: ""} parsedMac, _ := net.ParseMAC(intfinfo.MacAddress) // nil ```

6. The field `bgpLBEndPoint.macAddress` was removed - unused
7. The redundant `return` in `addRoute()` and `delRoute()` was removed
8. The `log` is initialized with `logrus.TextFormatter{FullTimestamp: true, DisableLevelTruncation: true}` - simpler to debug